### PR TITLE
Recaptchav3 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ echo form_close();
 ```
 helper(['form', 'reCaptcha']);
 
-echo form_open();
+echo form_open('/form_processing_path', array('id' => 'contactForm'));
 
 echo reCaptcha3('reCaptcha3', ['id' => 'recaptcha_v3'], ['action' => 'contactForm']);
 
@@ -71,6 +71,10 @@ public $validationRules = [
 ];
 ```
 
-In the settings of the reCaptcha3 validator, the first parameter you specify is expectedAction, this parameter is not required.
+In the settings of the reCaptcha3 validator, the first parameter you specify is
+expectedAction. The form id attribute needs to share the same name as the action.
+This allows grecaptcha.execute to be called on form submission to prevent token
+expiration warnings.
 
-You can override a global scoreThreshold parameter in the second reCaptcha3 rule parameter.
+You can override a global scoreThreshold parameter in the second reCaptcha3 rule
+parameter.

--- a/Views/init_v3.php
+++ b/Views/init_v3.php
@@ -9,7 +9,7 @@
 grecaptcha.ready(function() {
     grecaptcha.execute('<?= $key;?>', <?= json_encode($options);?>).then(function(token) {
         document.getElementById('<?= $id;?>').value = token;
-        document.getElementById('<?= $id;?>').oninput();
+        // document.getElementById('<?= $id;?>').oninput();
     });
 });
 

--- a/Views/init_v3.php
+++ b/Views/init_v3.php
@@ -7,10 +7,25 @@
 <script type="text/javascript">
 
 grecaptcha.ready(function() {
-    grecaptcha.execute('<?= $key;?>', <?= json_encode($options);?>).then(function(token) {
-        document.getElementById('<?= $id;?>').value = token;
-        // document.getElementById('<?= $id;?>').oninput();
-    });
+    var subCapStart = false;
+    var subCapInMotion = false;
+    var subCapForm = document.getElementById('<?= $options['action'] ?>');
+    subCapForm.addEventListener('submit', formCapSubmit);
+    function formCapSubmit(event){
+        if (!subCapStart){
+            event.preventDefault();
+            subCapStart = true;
+            grecaptcha.execute('<?= $key;?>', <?= json_encode($options);?>).then(function(token) {
+                document.getElementById('<?= $id;?>').value = token;
+                setTimeout(function(){subCapForm.submit();}, 500);
+                // document.getElementById('<?= $id;?>').oninput();
+            });
+        } else if (subCapInMotion){
+            // prevents double submission when activating grecaptcha
+            event.preventDefault();
+        }
+        subCapInMotion = true;
+    }
 });
 
 </script>


### PR DESCRIPTION
This example could probably be cleaned up or implemented a bit better within the your style here.  It forces the grecaptcha.execute to be called on form submission.  This helps prevent the token from expiring before the form is submitted.